### PR TITLE
Removing quotation marks with no attribution/citation.

### DIFF
--- a/pages/about.md
+++ b/pages/about.md
@@ -11,7 +11,7 @@ summary: The private sector quickly learns what does not work, what works, and w
 
 The Office of Evaluation Sciences (OES) brings diverse scientific expertise to Federal agencies and translates research insights into concrete recommendations for how to improve Federal programs, policies, and operations. OES then collaborates with agencies to implement, rigorously test, and evaluate the impact of these changes.
 
-Based at the General Services Administration (GSA), OES supports GSA’s Office of Government-wide Policy’s mission to serve agencies by helping them to “use policies, evidence, and analysis to drive efficiency, savings, and improved mission performance.”
+Based at the General Services Administration (GSA), OES supports GSA’s Office of Government-wide Policy’s mission to serve agencies by helping them to use policies, evidence, and analysis to drive efficiency, savings, and improved mission performance.
 
 ## What does OES do?
 


### PR DESCRIPTION
Since quotation marks either mean a word in a new meaning or context OR refer to other peoples language that should be cited, AND since we already refer to the OGP mission, I propose to remove the quotation marks.   Alternatively, we could make them a a direct link to the OGP mission.