### PR TITLE
Change sort order on projects to newest first and oldest last

### DIFF
--- a/_includes/projects.html
+++ b/_includes/projects.html
@@ -1,5 +1,5 @@
 <div class="project-container">
-{% for project in site.projects %}
+{% for project in site.projects reversed %}
   {% unless project.featured %}
     <article class="card usa-width-one-third js-filterable" {% for filter in layout.filters %}
     data-{{ filter.key }}='{{ project[filter.key] | jsonify | xml_escape }}'{% endfor %}>


### PR DESCRIPTION
👀 [Federalist Preview](https://federalist-proxy.app.cloud.gov/preview/gsa-oes/office-of-evaluation-sciences/project-sorting/work/)

Added the reversed variable to alter the sorting to show the most recent first.
Resolves issue https://github.com/gsa-oes/office-of-evaluation-sciences/issues/81

