### PR TITLE
allow hiding page image

### DIFF
--- a/_about/1-mission.md
+++ b/_about/1-mission.md
@@ -5,6 +5,7 @@ permalink: /mission/
 tags: blog
 image: /assets/img/icons/oes-green.jpg
 image_full: false
+hide_image: true
 class:
 summary: Deliver a better government for the public by enabling agencies to build and use evidence to continually learn what works.
 ---

--- a/_about/2-team.md
+++ b/_about/2-team.md
@@ -5,6 +5,7 @@ permalink: /team/
 tags: blog
 image: /assets/img/icons/oes-blue.jpg
 image_full: false
+hide_image: true
 class: page-team
 summary: Meet our current and former staff and affiliates who share a passion for applying their expertise to improve government.
 

--- a/_about/3-services.md
+++ b/_about/3-services.md
@@ -5,6 +5,7 @@ permalink: /services/
 tags: blog
 image: /assets/img/icons/oes-red.jpg
 image_full: false
+hide_image: true
 class:
 summary: Learn about the three types of work and services our team provides.
 ---

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -11,14 +11,16 @@ layout: default
   {% if page.summary %}
     <p class="billboard-message">{{ page.summary }}</p>
   {% endif %}
-  {% if page.image and page.image_full %}
-    <img src="{{ page.image | prepend: site.baseurl }}" alt="{{ page.image_alt_text }}">
-  {% elsif page.image %}
-    <div class="page--banner" style="background-image: url({{ page.image | prepend: site.baseurl }});" role="img" {% if page.image_alt_text %} aria-labelledby="caption"{% endif %}>
-    {% if page.image_alt_text %}
-      <p class="usa-sr-only" id="caption">{{ page.image_alt_text }}</p>
+  {% unless page.hide_image %}
+    {% if page.image and page.image_full %}
+      <img src="{{ page.image | prepend: site.baseurl }}" alt="{{ page.image_alt_text }}">
+    {% elsif page.image %}
+      <div class="page--banner" style="background-image: url({{ page.image | prepend: site.baseurl }});" role="img" {% if page.image_alt_text %} aria-labelledby="caption"{% endif %}>
+      {% if page.image_alt_text %}
+        <p class="usa-sr-only" id="caption">{{ page.image_alt_text }}</p>
+      {% endif %}
+      </div>
     {% endif %}
-    </div>
-  {% endif %}
+  {% endunless %}
   {{ content }}
 </div>


### PR DESCRIPTION
This makes the image on the actual page conditional, so it can be turned off by adding `hide_image: true` to the frontmatter of the page's markdown source code.