### PR TITLE
Remove team text & link

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -26,9 +26,6 @@
               <a href="{{ site.baseurl }}/about/">Mission</a>
             </li>
             <li>
-              <a href="{{ site.baseurl }}/team/">Team</a>
-            </li>
-            <li>
               <a href="{{ site.baseurl }}/services/">Services</a>
             </li>
           </ul>


### PR DESCRIPTION
This PR removes the text "Team" and the corresponding hyperlink associated with it from the footer of the page.