### PR TITLE
Add jekyll-redirect-from plugin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gem 'uswds-jekyll', :git => 'https://github.com/18F/uswds-jekyll.git', :branch =
 
 group :jekyll_plugins do
   gem 'jekyll-paginate'
+  gem 'jekyll-redirect-from'
   # gem 'jekyll-seo-tag'
   gem 'jekyll-sitemap'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,6 +19,7 @@ GEM
     eventmachine (1.2.7)
     eventmachine (1.2.7-x64-mingw32)
     ffi (1.15.5)
+    ffi (1.15.5-x64-mingw32)
     forwardable-extended (2.6.0)
     google-protobuf (3.25.5)
     http_parser.rb (0.8.0)
@@ -41,6 +42,8 @@ GEM
       terminal-table (>= 1.8, < 4.0)
       webrick (~> 1.7)
     jekyll-paginate (1.1.0)
+    jekyll-redirect-from (0.16.0)
+      jekyll (>= 3.3, < 5.0)
     jekyll-sass-converter (3.0.0)
       sass-embedded (~> 1.54)
     jekyll-sitemap (1.4.0)
@@ -83,6 +86,7 @@ PLATFORMS
 DEPENDENCIES
   jekyll
   jekyll-paginate
+  jekyll-redirect-from
   jekyll-sitemap
   uswds-jekyll!
 

--- a/_projects/2113B-ERA-equity.md
+++ b/_projects/2113B-ERA-equity.md
@@ -1,10 +1,12 @@
 ---
 title: Describing the distribution of Emergency Rental Assistance funds to those who need and qualify for it
-permalink: /projects/era-equity/
-tags: 
- - project
- - arp
- - housing
+permalink: /projects/era-descriptive/
+redirect_from:
+  - /projects/era-equity/
+tags:
+  - project
+  - arp
+  - housing
 share_image: /assets/img/project-images/2113B-image.jpg
 image: /assets/img/project-images/2113B-image.webp
 image_alt_text: Triple decker housing in Cambridge, MA
@@ -12,11 +14,11 @@ image-credit: https://commons.wikimedia.org/wiki/File:Cambridge-3deckers.webp
 analysis-plan: /assets/analysis/2113B-era-descriptive-study-of-equity-analysis-plan.pdf
 abstract: /assets/abstracts/2113B-era-descriptive-study-abstract.pdf
 technical-appendix: /assets/abstracts/2113B-technical-appendix.pdf
-year: 2022 
+year: 2022
 type: Descriptive study
-domain: 
-- Economic Opportunity
-- Pandemic Relief and Recovery
+domain:
+  - Economic Opportunity
+  - Pandemic Relief and Recovery
 agency: Treasury
 status: Complete
 summary: A descriptive study of the first-ever nationwide eviction prevention program
@@ -24,10 +26,12 @@ featured:
 ---
 
 ## What priority outcome did we evaluate?
-The first and second rounds of the Emergency Rental Assistance (ERA) program provided over $46 billion in funding to states, territories, Tribal governments, counties, and cities (“grantees”) to prevent eviction and housing instability in the wake of the pandemic. Overseen by the U.S. Department of the Treasury (“Treasury”), ERA provided direct cash assistance to renters and landlords to assist with rent, utilities, and other housing-related expenses. It was the first-ever nationwide program aimed at preventing eviction through direct assistance to renters. 
-We partnered with Treasury to understand how the demographic profile of renters who were eligible for ERA compared to the demographic profile of renters who received ERA. 
+
+The first and second rounds of the Emergency Rental Assistance (ERA) program provided over $46 billion in funding to states, territories, Tribal governments, counties, and cities (“grantees”) to prevent eviction and housing instability in the wake of the pandemic. Overseen by the U.S. Department of the Treasury (“Treasury”), ERA provided direct cash assistance to renters and landlords to assist with rent, utilities, and other housing-related expenses. It was the first-ever nationwide program aimed at preventing eviction through direct assistance to renters.
+We partnered with Treasury to understand how the demographic profile of renters who were eligible for ERA compared to the demographic profile of renters who received ERA.
 
 ## What were the key findings?
+
 - Extremely low income renters were overrepresented: at 64%, their share of the recipient population was twice their share of the eligible population.
 - Black renters were strongly overrepresented among recipients of ERA – their share of the recipient population was 21-22 percentage points higher than their share of the eligible population.
 - The share of recipients who identify as women was 14-15 percentage points higher than their share of eligible renters.
@@ -35,17 +39,19 @@ We partnered with Treasury to understand how the demographic profile of renters 
 - Consistent with other benefits programs, Asian renters were underrepresented among recipients of ERA.
 
 ## What did we do?
+
 We estimated the demographics of renters using grantee reports on households who received ERA (which included gender, race, ethnicity, and income) and compared this to the profile of ERA-eligible renters, estimated using Census data. We took a multiple datasets approach to estimate differences in the race, ethnicity, gender, and income of renters who received and renters who were eligible for ERA.
 
 <img src="{{ '/assets/img/project-images/2113B-fig0.svg' | prepend: site.baseurl }}" alt="" width="1500">
 <i><a href="/assets/img/project-images/2113B-fig0.svg">Expand image</a></i>
 
 ## What did we learn?
-Existing research illustrates that Black and women renters were the most likely to receive eviction notices prior to the pandemic. In ERA, an unprecedented rental assistance program that Treasury and hundreds of grantees stood up and implemented in a number of months, OES found that those renters were most likely to receive funds, across all regions of the US. 
+
+Existing research illustrates that Black and women renters were the most likely to receive eviction notices prior to the pandemic. In ERA, an unprecedented rental assistance program that Treasury and hundreds of grantees stood up and implemented in a number of months, OES found that those renters were most likely to receive funds, across all regions of the US.
 
 Renters who identify as Native American, Alaska Native, Pacific Islander, or Hawaiian Native were overrepresented among recipients, which is notable given OES likely underestimated receipt by these groups due to the unavailability of demographic data from Tribal governments. Due to incompatibility between datasets, we were unable to estimate over- and underrepresentation of those who identify as Non-Binary or as Mixed Race.
 
-Among eligible renters, ERA funds were much more likely to reach those with the lowest incomes. This matters for the representation of ethnic and racial groups, because income distributions vary by race and ethnicity. OES estimated underrepresentation of White and Latinx renters only at the higher end of the eligible income spectrum—extremely low income White and Latinx renters were overrepresented among recipients. For Asian renters, who were underrepresented in the program, gaps appeared less stark when accounting for income but remained nonetheless. The category “Asian”  represents a diverse group of ERA-eligible renters who, according to analyses in the <a href="/assets/abstracts/2113B-technical-appendix.pdf">technical appendix</a>, generally have low uptake of other government programs. OES recommends further research focusing on ways to boost access to and receipt of government benefits among this group.
+Among eligible renters, ERA funds were much more likely to reach those with the lowest incomes. This matters for the representation of ethnic and racial groups, because income distributions vary by race and ethnicity. OES estimated underrepresentation of White and Latinx renters only at the higher end of the eligible income spectrum—extremely low income White and Latinx renters were overrepresented among recipients. For Asian renters, who were underrepresented in the program, gaps appeared less stark when accounting for income but remained nonetheless. The category “Asian” represents a diverse group of ERA-eligible renters who, according to analyses in the <a href="/assets/abstracts/2113B-technical-appendix.pdf">technical appendix</a>, generally have low uptake of other government programs. OES recommends further research focusing on ways to boost access to and receipt of government benefits among this group.
 
 <b>Figure 1.</b> Demographic characteristics of renters who received and renters who were eligible for ERA.
 <img src="{{ '/assets/img/project-images/2113B-fig1.webp' | prepend: site.baseurl }}" alt="" width="1500">

--- a/_projects/2302-ARP-ACA.md
+++ b/_projects/2302-ARP-ACA.md
@@ -1,7 +1,9 @@
 ---
 title: Identifying interventions to increase Affordable Care Act uptake through a systematic review and meta-analysis
-permalink: /projects/ARP-ACA/
-tags: 
+permalink: /projects/affordable-care-act/
+redirect_from:
+  - /projects/ARP-ACA/
+tags:
   - project
   - arp
   - health insurance
@@ -17,17 +19,19 @@ domain: Pandemic Relief and Recovery
 agency: Health and Human Services
 status: Complete
 summary: Support-based interventions increase health insurance enrollment
-featured: 
-
+featured:
 ---
 
-## What did we evaluate? 
-The passage of the American Rescue Plan Act (ARP) in 2021 and Inflation Reduction Act (IRA) in 2022 dramatically expanded the Affordable Care Act’s (ACA) subsidies through the end of 2025. These policies have contributed to record-high marketplace enrollment.<sup>1</sup> Despite these coverage gains, an estimated 10.9 million individuals eligible for subsidized health insurance remained uninsured in 2021, possibly due in part to a lack of awareness of low-cost coverage options available through the marketplaces.<sup>2</sup>  In addition, with the end of the federal COVID-19 Public Health Emergency in April 2023, approximately 15 million individuals are projected to lose Medicaid and Children's Health Insurance Program coverage.<sup>3</sup> The Department of Health and Human Services (HHS) and state-based marketplaces seek to understand what types of outreach are most effective at increasing ACA uptake among prospective marketplace enrollees.
+## What did we evaluate?
+
+The passage of the American Rescue Plan Act (ARP) in 2021 and Inflation Reduction Act (IRA) in 2022 dramatically expanded the Affordable Care Act’s (ACA) subsidies through the end of 2025. These policies have contributed to record-high marketplace enrollment.<sup>1</sup> Despite these coverage gains, an estimated 10.9 million individuals eligible for subsidized health insurance remained uninsured in 2021, possibly due in part to a lack of awareness of low-cost coverage options available through the marketplaces.<sup>2</sup> In addition, with the end of the federal COVID-19 Public Health Emergency in April 2023, approximately 15 million individuals are projected to lose Medicaid and Children's Health Insurance Program coverage.<sup>3</sup> The Department of Health and Human Services (HHS) and state-based marketplaces seek to understand what types of outreach are most effective at increasing ACA uptake among prospective marketplace enrollees.
 
 ## How did the evaluation work?
+
 This study uses a systematic review and meta-analysis to summarize evidence on interventions meant to increase ACA marketplace enrollment. This approach facilitates comparing the efficacy of various interventions on enrollment, providing decision-makers in state health exchanges and the federal marketplace with useful evidence as they consider approaches to encouraging enrollment.
 
 ## What did we learn?
+
 Based on a meta-analysis of 34 studies with a combined sample size of over 18 million people, we found that on average, the rate of enrollment was close to one percentage point higher for those who received an intervention, a 24% increase relative to the control group. The average base rate of enrollment in control groups, weighted by control group sample size, was 3.7%.
 
 Interventions providing enrollment support tended to be more effective than those providing information alone. Support-based interventions increased enrollment by 2 percentage points, while information-based interventions increased enrollment by 0.6 percentage points.
@@ -38,8 +42,9 @@ Interventions providing enrollment support tended to be more effective than thos
 From this, we learned that outreach interventions can increase take-up. Increasing enrollment through addressing administrative burdens will be most effective when focused on providing information and support, rather than information alone.
 
 Notes:
-1. Ortaliza, Jared, Krutika Amin, Cynthia Cox. <a class="usa-link usa-link--external" href="https://www.kff.org/private-insurance/issue-brief/as-aca-marketplace-enrollment-reaches-record-high-fewer-are-buying-individual-market-coverage-elsewhere/">As ACA Marketplace enrollment reaches record high, fewer are buying individual market coverage elsewhere.</a> 2023. KFF. 
-2. McDermott, Daniel, Cynthia Cox. <a class="usa-link usa-link--external" href="https://www.kff.org/private-insurance/issue-brief/a-closer-look-at-the-uninsured-marketplace-eligible-population-following-the-american-rescue-plan-act/">A closer look at the uninsured Marketplace eligible population following the American Rescue Plan Act.</a> 2021. KFF.
-3. <a class="usa-link usa-link--external" href="https://aspe.hhs.gov/sites/default/files/documents/dc73e82abf7fc26b6a8e5cc52ae42d48/aspe-end-mcaid-continuous-coverage.pdf">Unwinding the Medicaid Continuous Enrollment Provision: Projected Enrollment Effects and Policy Approaches (Issue Brief HP-2022-20)</a> Washington, DC: Office of the Assistant Secretary for Planning and Evaluation, U.S. Department of Health and Human Services. August 19, 2022.  
 
-Verify the upload date of our analysis plan <a class="usa-link usa-link--external" href="https://github.com/gsa-oes/office-of-evaluation-sciences/commits/master/assets/analysis/2302-ARP-ACA-analysis.pdf">on GitHub</a>. 
+1. Ortaliza, Jared, Krutika Amin, Cynthia Cox. <a class="usa-link usa-link--external" href="https://www.kff.org/private-insurance/issue-brief/as-aca-marketplace-enrollment-reaches-record-high-fewer-are-buying-individual-market-coverage-elsewhere/">As ACA Marketplace enrollment reaches record high, fewer are buying individual market coverage elsewhere.</a> 2023. KFF.
+2. McDermott, Daniel, Cynthia Cox. <a class="usa-link usa-link--external" href="https://www.kff.org/private-insurance/issue-brief/a-closer-look-at-the-uninsured-marketplace-eligible-population-following-the-american-rescue-plan-act/">A closer look at the uninsured Marketplace eligible population following the American Rescue Plan Act.</a> 2021. KFF.
+3. <a class="usa-link usa-link--external" href="https://aspe.hhs.gov/sites/default/files/documents/dc73e82abf7fc26b6a8e5cc52ae42d48/aspe-end-mcaid-continuous-coverage.pdf">Unwinding the Medicaid Continuous Enrollment Provision: Projected Enrollment Effects and Policy Approaches (Issue Brief HP-2022-20)</a> Washington, DC: Office of the Assistant Secretary for Planning and Evaluation, U.S. Department of Health and Human Services. August 19, 2022.
+
+Verify the upload date of our analysis plan <a class="usa-link usa-link--external" href="https://github.com/gsa-oes/office-of-evaluation-sciences/commits/master/assets/analysis/2302-ARP-ACA-analysis.pdf">on GitHub</a>.

--- a/_projects/2407-arp-liheap.md
+++ b/_projects/2407-arp-liheap.md
@@ -1,7 +1,9 @@
 ---
 title: Evaluating the effect of changes to the Low Income Home Energy Assistance Program
-permalink: /2407-arp-liheap/
-tags: 
+permalink: /2407-liheap/
+redirect_from:
+  - /2407-arp-liheap/
+tags:
   - project
   - arp
   - housing
@@ -10,17 +12,18 @@ image: /assets/img/project-images/2407-new.webp
 image-credit: https://www.flickr.com/photos/151653494@N04/32459483054/
 image_alt_text: Person adjusting thermostat
 analysis-plan: /assets/analysis/2407-liheap-summer-fill-analysis-plan.pdf
-abstract: 
-year: 2024  
+abstract:
+year: 2024
 domain:
- - Housing
- - Pandemic Relief and Recovery
+  - Housing
+  - Pandemic Relief and Recovery
 type: Impact evaluation of program change
 agency: Health and Human Services
 status: Ongoing
 summary: Analysis plan registration
-featured: 
+featured:
 ---
+
 This evaluation is currently being implemented. We have created this project page as a mechanism to pre-specify what data will be collected, what we plan to measure, and how we’ll conduct our analysis. We believe this is a critical component of conducting transparent, replicable, and high-quality research; and aim to share our Analysis Plans whenever possible.
 
 The Analysis Plan at the right indicates the date locked, and you can verify our upload date <a class="usa-link usa-link--external" href="https://github.com/gsa-oes/office-of-evaluation-sciences/commits/master/assets/analysis/2407-liheap-summer-fill-analysis-plan.pdf">on GitHub</a>.


### PR DESCRIPTION
- Adds the jekyll-redirect-from plugin
- Creates redirects for:
  - /projects/era-equity/ to /projects/era-descriptive
  - /projects/ARP-ACA/ to /projects/affordable-care-act
  - /2407-arp-liheap/ to /2407-liheap